### PR TITLE
PyBullet argument list reduction via whitespace removal

### DIFF
--- a/panda_gym/pybullet.py
+++ b/panda_gym/pybullet.py
@@ -25,9 +25,7 @@ class PyBullet:
     def __init__(self, render: bool = False, n_substeps: int = 20, background_color: Optional[np.ndarray] = None) -> None:
         background_color = background_color if background_color is not None else np.array([223.0, 54.0, 45.0])
         self.background_color = background_color.astype(np.float32) / 255
-        options = "--background_color_red={} \
-                    --background_color_green={} \
-                    --background_color_blue={}".format(
+        options = "--background_color_red={} --background_color_green={} --background_color_blue={}".format(
             *self.background_color
         )
         self.connection_mode = p.GUI if render else p.DIRECT


### PR DESCRIPTION
Adresses #43. Previously, over 40 command line arguments were sent to PyBullet and printed to the console due to extra spaces in the `options` string. This minor change reduces this to 3 background color command line arguments.